### PR TITLE
Disable Preseal for testnet

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -246,7 +246,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
-	// NOTE: Preseal is disabled for now, check whether testnet syncing issue is resolved
+	// NOTE: Preseal is disabled to resolve testnet syncing issue
 	// https://github.com/oasysgames/oasys-validator/issues/42https://github.com/oasysgames/oasys-validator/issues/42
 	eth.miner.DisablePreseal()
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -246,6 +246,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	// NOTE: Preseal is disabled for now, check whether testnet syncing issue is resolved
+	// https://github.com/oasysgames/oasys-validator/issues/42https://github.com/oasysgames/oasys-validator/issues/42
+	eth.miner.DisablePreseal()
 
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {


### PR DESCRIPTION
Preseal is a potential cause of the syncing issues on the testnet(#42). We will monitor the testnet to see if the syncing issues persist after applying this change.