### PR TITLE
Fix voting process stopping with each synchronization

### DIFF
--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -412,7 +412,7 @@ func (ps *peerSet) peerWithHighestJustifiedBlockAndTD() (bestPeer *eth.Peer, bes
 			continue
 		}
 		_, td := p.Head()
-		if *justified > bestJustified || (*justified == bestJustified && td.Cmp(bestTd) > 0) {
+		if bestPeer == nil || *justified > bestJustified || (*justified == bestJustified && td.Cmp(bestTd) > 0) {
 			bestPeer, bestJustified, bestTd = p.Peer, *justified, td
 		}
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -182,8 +182,8 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 			if peerJustified < *ourJustified {
 				return nil
 			}
-			// Ignored because justified block height is the same but TD is lower.
-			if peerJustified == *ourJustified && peerTD.Cmp(ourTD) < 0 {
+			// Ignored because justified block height is the same but TD is the same or lower.
+			if peerJustified == *ourJustified && peerTD.Cmp(ourTD) <= 0 {
 				return nil
 			}
 		}


### PR DESCRIPTION
downloaderの同期処理が走る度にvoting_poolが停止するためSafeブロックがひとつ飛ばしで行われるようになっていました。