### PR TITLE
fix node crash issue when solidity block.difficulity or block.prevran…

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -91,13 +91,14 @@ func newCancunInstructionSet() JumpTable {
 }
 
 func newShanghaiInstructionSet() JumpTable {
-	instructionSet := newMergeInstructionSet()
+	instructionSet := newLondonInstructionSet()
 	enable3855(&instructionSet) // PUSH0 instruction
 	enable3860(&instructionSet) // Limit and meter initcode
 
 	return validate(instructionSet)
 }
 
+// Skip the Merge instruction set, as Oasys does not support RANDAO
 func newMergeInstructionSet() JumpTable {
 	instructionSet := newLondonInstructionSet()
 	instructionSet[PREVRANDAO] = &operation{


### PR DESCRIPTION
Addressing Node Crash Issue Due to Null Pointer Access in BlockContext.Random

The node crash issue is caused by a null pointer access of `BlockContext.Random`. Since we don’t support RANDAO, this value is always null. The crash occurs when code in a smart contract attempts to access `block.difficulty` or `block.prevrandao`, triggering a call to this null value.

#### Sample Contract
```solidity
contract L1Block {
    uint256 public lastData;

    function difficulty() public {
        lastData = block.difficulty;
    }

    function prevrandao() public {
        lastData = block.prevrandao;
    }
}
```