### PR TITLE
fix blob freeze bug on localchain

### DIFF
--- a/consensus/oasys/contract.go
+++ b/consensus/oasys/contract.go
@@ -253,7 +253,7 @@ func (c *Oasys) IsSystemTransaction(tx *types.Transaction, header *types.Header)
 	}
 
 	if sender, err := types.Sender(c.txSigner, tx); err != nil {
-		return false, errors.New("unauthorized transaction")
+		return false, fmt.Errorf("unauthorized transaction: %w", err)
 	} else if sender != header.Coinbase {
 		// not created by validator
 		return false, nil

--- a/consensus/oasys/oasys.go
+++ b/consensus/oasys/oasys.go
@@ -217,7 +217,7 @@ func New(chainConfig *params.ChainConfig, config *params.OasysConfig, db ethdb.D
 		signatures:  signatures,
 		proposals:   make(map[common.Address]bool),
 		ethAPI:      ethAPI,
-		txSigner:    types.MakeSigner(chainConfig, common.Big0, 0),
+		txSigner:    types.LatestSigner(chainConfig),
 	}
 }
 

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -356,7 +356,6 @@ func (f *chainFreezer) freezeRangeWithBlobs(nfdb *nofreezedb, number, limit uint
 }
 
 func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hashes []common.Hash, err error) {
-	log.Debug("freezeRange is called", "number", number, "to", limit)
 	if number > limit {
 		return nil, nil
 	}
@@ -365,7 +364,6 @@ func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hash
 	hashes = make([]common.Hash, 0, limit-number)
 	_, err = f.ModifyAncients(func(op ethdb.AncientWriteOp) error {
 		for ; number <= limit; number++ {
-			log.Debug("freezeRange: loop", "number", number)
 			// Retrieve all the components of the canonical block.
 			hash := ReadCanonicalHash(nfdb, number)
 			if hash == (common.Hash{}) {
@@ -391,7 +389,6 @@ func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hash
 			var sidecars rlp.RawValue
 			if isCancun(env, h.Number, h.Time) {
 				sidecars = ReadBlobSidecarsRLP(nfdb, hash, number)
-				log.Debug("freezeRange: isCancun", "number", number, "sidecars", sidecars)
 				if len(sidecars) == 0 {
 					return fmt.Errorf("block blobs missing, can't freeze block %d", number)
 				}
@@ -414,7 +411,6 @@ func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hash
 				return fmt.Errorf("can't write td to Freezer: %v", err)
 			}
 			if isCancun(env, h.Number, h.Time) {
-				log.Debug("freezeRange: isCancun 2", "number", number, "sidecars", sidecars)
 				if err := op.AppendRaw(ChainFreezerBlobSidecarTable, number, sidecars); err != nil {
 					return fmt.Errorf("can't write blobs to Freezer: %v", err)
 				}

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -387,11 +387,7 @@ func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hash
 			}
 			// blobs is nil before cancun fork
 			var sidecars rlp.RawValue
-<<<<<<< HEAD
 			if isCancun(env, h.Number, h.Time) {
-=======
-			if isCancun(env, h.Number, h.Time) && number != 0 { // except genesis block in case of development
->>>>>>> main
 				sidecars = ReadBlobSidecarsRLP(nfdb, hash, number)
 				if len(sidecars) == 0 {
 					return fmt.Errorf("block blobs missing, can't freeze block %d", number)
@@ -414,11 +410,7 @@ func (f *chainFreezer) freezeRange(nfdb *nofreezedb, number, limit uint64) (hash
 			if err := op.AppendRaw(ChainFreezerDifficultyTable, number, td); err != nil {
 				return fmt.Errorf("can't write td to Freezer: %v", err)
 			}
-<<<<<<< HEAD
 			if isCancun(env, h.Number, h.Time) {
-=======
-			if isCancun(env, h.Number, h.Time) && number != 0 { // except genesis block in case of development
->>>>>>> main
 				if err := op.AppendRaw(ChainFreezerBlobSidecarTable, number, sidecars); err != nil {
 					return fmt.Errorf("can't write blobs to Freezer: %v", err)
 				}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -155,6 +155,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Override the chain config with provided settings.
+	var overrides core.ChainOverrides
+	if config.OverrideCancun != nil {
+		chainConfig.CancunTime = config.OverrideCancun
+		overrides.OverrideCancun = config.OverrideCancun
+	}
+	if config.OverrideVerkle != nil {
+		chainConfig.VerkleTime = config.OverrideVerkle
+		overrides.OverrideVerkle = config.OverrideVerkle
+	}
+
 	// startup ancient freeze
 	if err = chainDb.SetupFreezerEnv(&ethdb.FreezerEnv{
 		ChainCfg:         chainConfig,
@@ -225,14 +236,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			StateScheme:         scheme,
 		}
 	)
-	// Override the chain config with provided settings.
-	var overrides core.ChainOverrides
-	if config.OverrideCancun != nil {
-		overrides.OverrideCancun = config.OverrideCancun
-	}
-	if config.OverrideVerkle != nil {
-		overrides.OverrideVerkle = config.OverrideVerkle
-	}
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err

--- a/params/config.go
+++ b/params/config.go
@@ -744,6 +744,10 @@ func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64, time u
 // CheckConfigForkOrder checks that we don't "skip" any forks, geth isn't pluggable enough
 // to guarantee that forks can be implemented in a different order than on official networks
 func (c *ChainConfig) CheckConfigForkOrder() error {
+	// skip checking for non-Oasys egine
+	if c.Oasys == nil {
+		return nil
+	}
 	type fork struct {
 		name      string
 		block     *big.Int // forks up to - and including the merge - were defined with block numbers


### PR DESCRIPTION
BlobのFreezeで次のエラーが発生
```
2024-11-28 10:03:05 ERROR[11-28|03:03:05.530] Error in block freeze operation          err="can't write blobs to Freezer: the append operation is out-order: have 1 want 0"
```
どうやらgenesisの次のBlockをFreezeしようとしたときに発生する
localチェーンでgenesisからcancunを適応することを想定して、[BSCと異なる実装](https://github.com/oasysgames/oasys-validator/pull/86/commits/1d9369b3f8ccb853fbad3c524fad2cf1c692bf19)をとっていたことが原因。

BSCの実装に戻す改修を行なった。
これにより、localチェーンでgenesisからcauncunを適応する場合、Freezeでエラーが発生するので注意が必要。