### PR TITLE
address failed to load latest signer at first place issue

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -356,6 +356,25 @@ var (
 	TestRules = TestChainConfig.Rules(new(big.Int), false, 0)
 )
 
+func GetBuiltInChainConfig(ghash common.Hash) *ChainConfig {
+	switch ghash {
+	case MainnetGenesisHash:
+		return MainnetChainConfig
+	case HoleskyGenesisHash:
+		return HoleskyChainConfig
+	case SepoliaGenesisHash:
+		return SepoliaChainConfig
+	case GoerliGenesisHash:
+		return GoerliChainConfig
+	case OasysMainnetGenesisHash:
+		return OasysMainnetChainConfig
+	case OasysTestnetGenesisHash:
+		return OasysTestnetChainConfig
+	default:
+		return nil
+	}
+}
+
 // NetworkNames are user friendly names to use in the chain spec banner.
 var NetworkNames = map[string]string{
 	MainnetChainConfig.ChainID.String(): "mainnet",

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1  // Major version component of the current release
 	VersionMinor = 7  // Minor version component of the current release
-	VersionPatch = 2  // Patch version component of the current release
+	VersionPatch = 3  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
After the v1.7 hard fork, which introduced support for Cancun, and the first blob transaction was included in the chain, the L1 network became unstable. This has resulted in nodes being unable to sync with each other. 
The following `BAD BLOCK` error has been observed in our RPC node.
```
########## BAD BLOCK #########
Validator: 0xe4838b9fd06307ed4ee9bd105d605d4917fae30f
Number: 5527503
Hash: 0xba8016e12c6c8c54d1f03891d5196069db91f2065818dcc40f076de1fc172d53
ParentHash: 0xcd67e24f24376b5bfe15e8f4bc8dd72505287e7cb43ca748df8f535de926aa66
Time: 1734509473
Difficulty: 29000
ReceiptHash: 0x59ecb8f7a6d9783f3593343f9a7ba44e402417c2b66b25cb46233732daff29ff
Root: 0x85a18cb374990271e179c2cf1d341985df44c929574a147e431af90826eb15e6
Extra: 0xd983010702846765746889676f312e32312e3133856c696e7578000000000000f8b4847bb7f5f8b860b3f80d39e0634651780c4b00c80dabf64ac9e74465c02d6f87a6f48e73a16baef3fb10aed3e3e624953ec7b4822c5c7216e19615641d0acb3b0b06f3fa87db408d601049b5437165a17e7738407cbcb1131abbc71789e3827a8095eccaef7a22f84a835457cda00b55d362e432fd5f73003fc872077eaf29bf5c6a25a973d1995ac487855be3a3835457cea0cd67e24f24376b5bfe15e8f4bc8dd72505287e7cb43ca748df8f535de926aa6680be16c2efc119a8ea41f122996f248804ba4587ace03c346da8b35bc176af62ed2261782e95ea5457a77f013674b64955814a3087b49a71f189239e6ef0caffca00
Transactions: 6
Error: unauthorized transaction: transaction type not supported
Platform: geth (devel) go1.21.13 amd64 linux
VCS: 4e08e529-
Chain config: &params.ChainConfig{ChainID:248, HomesteadBlock:0, DAOForkBlock:<nil>, DAOForkSupport:false, EIP150Block:0, EIP155Block:0, EIP158Block:0, ByzantiumBlock:0, ConstantinopleBlock:0, PetersburgBlock:0, IstanbulBlock:0, MuirGlacierBlock:0, BerlinBlock:0, LondonBlock:0, ArrowGlacierBlock:<nil>, GrayGlacierBlock:<nil>, MergeNetsplitBlock:<nil>, ShanghaiTime:(*uint64)(0xc000269138), CancunTime:(*uint64)(0xc000269140), PragueTime:(*uint64)(nil), VerkleTime:(*uint64)(nil), TerminalTotalDifficulty:<nil>, TerminalTotalDifficultyPassed:false, Ethash:(*params.EthashConfig)(nil), Clique:(*params.CliqueConfig)(nil), Oasys:(*params.OasysConfig)(0x40898a0)}
Receipts:
##############################
```

### Why?
[here](https://github.com/ironbeer/oasys-validator/blob/main/consensus/oasys/contract.go#L256) is the code error thrown.
The error occurs because the signer in the Oasys consensus is not compatible with Cancun. This indicates that the latest chain configuration was not applied when creating the consensus engine.

### Solution
To resolve this issue, we load the latest chainConfig before creating the consensus engine.