### PR TITLE
prevent `Syncing, discarded` warning

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -549,6 +549,9 @@ func (s *Ethereum) StartMining() error {
 				return fmt.Errorf("temporarily force validators to enable voting. Please proceed with registering your BLS key. For more details, refer to the technical documentation: %s, err: %v", techDocRef, err)
 			}
 		}
+		// If mining is started, we can disable the transaction rejection mechanism
+		// introduced to speed sync times.
+		s.handler.enableSyncedFeatures()
 
 		go s.miner.Start()
 	}


### PR DESCRIPTION
### 再現
Validator数が2のネットワークにして、スタート直後からBLS鍵を登録すると、Stake量の多いValidatorが、Stake量の少ない方のValidatorのブロック取り込めなくなる。
観測されるログとしては
`Syncing, discarded propagated block`というWarningの後に、`Re-queue blocks`というログが大量に出るようになる
```
2025-04-25 10:43:25.013 | WARN [04-25|08:43:25.013] Syncing, discarded propagated block      number=22 hash=ca6701..9b3c86
2025-04-25 10:43:26.953 | INFO [04-25|08:43:26.953] Commit new sealing work                  number=22 sealhash=cc733d..9215a5 timestamp=1,745,570,607 txs=0 blobs=0 gas=80734   elapsed=1.948s
2025-04-25 10:43:27.004 | INFO [04-25|08:43:27.004] Successfully sealed new block            number=22 sealhash=cc733d..9215a5 hash=9eb6a4..6f8ee7 timestamp=1,745,570,607 elapsed=51.103ms
2025-04-25 10:43:27.992 | INFO [04-25|08:43:27.992] Looking for peers                        peercount=2 tried=0 static=0
2025-04-25 10:43:31.510 | INFO [04-25|08:43:31.509] Re-queue blocks                          number=23 hash=0x4e4b43449d7cf97b51fffd02530bdc21c3c734df37d6496c805486a0151b9829
2025-04-25 10:43:32.010 | INFO [04-25|08:43:32.010] Re-queue blocks                          number=23 hash=0x4e4b43449d7cf97b51fffd02530bdc21c3c734df37d6496c805486a0151b9829
2025-04-25 10:43:32.512 | INFO [04-25|08:43:32.511] Re-queue blocks                          number=23 hash=0x4e4b43449d7cf97b51fffd02530bdc21c3c734df37d6496c805486a0151b9829
```

### 原因
Stake量の多い方のValidatorの方が[JustifyBlockとTotalDifficulitが高いために、Stake量の少ないValidastorとのSyncを拒否している](https://github.com/oasysgames/oasys-validator/blob/v1.7.4/eth/sync.go#L181-L189)ことが原因

この挙動自体は正しいように思う。
しかし、単一Validatorがネットワークの多数を占めているとき（自分のJustifyBlockやTDが、別Validatorに追い越されることが起こりにくいとき）、マイナーバリデータとの同期を開始できないのは、ローカル環境でのテスト時に支障があるので、改修する

### 対策
Miningが有効の場合は、Syncを直ちに始めることにした。
該当の箇所は、[BSCでは削除されてる](https://github.com/bnb-chain/bsc/pull/2834)。
Oasysでは、BSCと取り込んだ時に消えた。それを復活させた