### PR TITLE
set v1.8.0 testnet hardfork

### DIFF
--- a/contracts/oasys/deployments.go
+++ b/contracts/oasys/deployments.go
@@ -41,7 +41,7 @@ var deploymentSets = map[common.Hash]map[uint64]deploymentSet{
 		4017600: deploymentSet{deployments11},
 		4958700: deploymentSet{deployments12},
 		5445775: deploymentSet{deployments13},
-		9999999: deploymentSet{deployments14, deployments14_slash_indicator_testnet},
+		8496170: deploymentSet{deployments14, deployments14_slash_indicator_testnet}, // Fri Jul 04 2025 10:00:00 GMT+0900
 	},
 	defaultGenesisHash: {
 		2: deploymentSet{

--- a/contracts/oasys/oasys_test.go
+++ b/contracts/oasys/oasys_test.go
@@ -1256,9 +1256,8 @@ func TestDeploy(t *testing.T) {
 				{blockNumber: 4017600, deploy: []deployFn{_deployments11}},
 				{blockNumber: 4958700, deploy: []deployFn{_deployments12}},
 				{blockNumber: 5445775, deploy: []deployFn{_deployments13}},
-				// TODO: Uncomment when `OasysTestnetChainConfig.PragueTime` is set
-				// {blockNumber: 5445775 + 1, blockTime: 9999999999, deploy: []deployFn{_deployEIP2935}},
-				{blockNumber: 9999999, deploy: []deployFn{_deployments14}},
+				{blockNumber: 8496170 - 1, blockTime: 1751590860, deploy: []deployFn{_deployEIP2935}},
+				{blockNumber: 8496170, deploy: []deployFn{_deployments14}},
 			},
 		},
 		{

--- a/params/config.go
+++ b/params/config.go
@@ -281,7 +281,7 @@ var (
 		LondonBlock:         big.NewInt(0),
 		ShanghaiTime:        newUint64(1718600000), // Mon Jun 17 2024 13:53:20 GMT+0900
 		CancunTime:          newUint64(1733288400), // Wed Dec 04 2024 14:00:00 GMT+0900
-		// PragueTime:          newUint64(9999999999), // TODO
+		PragueTime:          newUint64(1751590860), // Fri Jul 04 2025 10:01:00 GMT+0900
 
 		Oasys: &OasysConfig{
 			Period: 15,


### PR DESCRIPTION
テストネットのハードフォークを金曜の１０時からにスケジューリングしました。
コントラクトのDeployを気持ちだけ早めに設定してます。こちらは失敗する可能性が低いので。
（もし、Pragueの適応が失敗しても、コントラクトはデプロイされていて欲しい。