### PR TITLE
Fix Blob schedule error on startup

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -289,7 +289,7 @@ var (
 		},
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
-			// Prague: DefaultPragueBlobConfig, // TODO
+			Prague: DefaultPragueBlobConfig,
 		},
 	}
 


### PR DESCRIPTION
```
Started Validator for Oasys Blockchain..
INFO [07-02|07:19:59.738] Starting pprof server                    addr=http://0.0.0.0:6061/debug/pprof
INFO [07-02|07:19:59.746] Maximum peer count                       ETH=50 total=50
INFO [07-02|07:19:59.747] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [07-02|07:19:59.749] Enabling recording of key preimages since archive mode is used
WARN [07-02|07:19:59.749] Disabled transaction unindexing for archive node
WARN [07-02|07:19:59.749] Forcing hash state-scheme for archive mode
INFO [07-02|07:19:59.749] Set global gas cap                       cap=50,000,000
INFO [07-02|07:19:59.750] Initializing the KZG library             backend=gokzg
INFO [07-02|07:19:59.863] Using leveldb as the backing database
INFO [07-02|07:19:59.863] Allocated cache and file handles         database=/home/geth/.ethereum/geth/chaindata cache=408.00MiB handles=262,144
INFO [07-02|07:20:00.120] Using LevelDB as the backing database
INFO [07-02|07:20:00.121] Found legacy ancient chain path          location=/home/geth/.ethereum/geth/chaindata/ancient
INFO [07-02|07:20:00.857] Opened ancient database                  database=/home/geth/.ethereum/geth/chaindata/ancient readonly=false frozen=8,381,152
INFO [07-02|07:20:00.858] State scheme set by user                 scheme=hash
INFO [07-02|07:20:00.858] Allocated memory caches                  state_scheme=hash trie_clean_cache=306.00MiB trie_dirty_cache=0.00B snapshot_cache=306.00MiB
INFO [07-02|07:20:00.962] Initialising Ethereum protocol           network=9372 dbversion=9
Fatal: Failed to register the Ethereum service: invalid chain configuration: missing entry for fork "prague" in blobSchedule
geth.service: Main process exited, code=exited, status=1/FAILURE
geth.service: Failed with result 'exit-code'.
```