### PR TITLE
schecule mainnet hardfork for v1.8.0

### DIFF
--- a/contracts/oasys/deployments.go
+++ b/contracts/oasys/deployments.go
@@ -25,7 +25,7 @@ var deploymentSets = map[common.Hash]map[uint64]deploymentSet{
 		4089588: deploymentSet{deployments11},
 		5095900: deploymentSet{deployments12},
 		5527429: deploymentSet{deployments13},
-		9999999: deploymentSet{deployments14, deployments14_slash_indicator_mainnet},
+		8728540: deploymentSet{deployments14, deployments14_slash_indicator_mainnet}, // Fri Jul 29 2025 13:00:00 GMT+0900
 	},
 	params.OasysTestnetGenesisHash: {
 		1:       deploymentSet{deployments0},

--- a/contracts/oasys/oasys_test.go
+++ b/contracts/oasys/oasys_test.go
@@ -1233,9 +1233,8 @@ func TestDeploy(t *testing.T) {
 				{blockNumber: 4089588, deploy: []deployFn{_deployments11}},
 				{blockNumber: 5095900, deploy: []deployFn{_deployments12}},
 				{blockNumber: 5527429, deploy: []deployFn{_deployments13}},
-				// TODO: Uncomment when `OasysMainnetChainConfig.PragueTime` is set
-				// {blockNumber: 5527429 + 1, blockTime: 9999999999, deploy: []deployFn{_deployEIP2935}},
-				{blockNumber: 9999999, deploy: []deployFn{_deployments14}},
+				{blockNumber: 8728540 - 1, blockTime: 1753761660, deploy: []deployFn{_deployEIP2935}},
+				{blockNumber: 8728540, deploy: []deployFn{_deployments14}},
 			},
 		},
 		{

--- a/params/config.go
+++ b/params/config.go
@@ -254,7 +254,7 @@ var (
 		LondonBlock:         big.NewInt(0),
 		ShanghaiTime:        newUint64(1721910600), // Thu Jul 25 2024 21:30:00 GMT+0900
 		CancunTime:          newUint64(1734508800), // Wed Dec 18 2024 17:00:00 GMT+0900
-		// PragueTime:          newUint64(9999999999), // TODO
+		PragueTime:          newUint64(1753761660), // Tue Jul 29 2025 13:01:00 GMT+0900
 
 		Oasys: &OasysConfig{
 			Period: 15,
@@ -262,7 +262,7 @@ var (
 		},
 		BlobScheduleConfig: &BlobScheduleConfig{
 			Cancun: DefaultCancunBlobConfig,
-			// Prague: DefaultPragueBlobConfig, // TODO
+			Prague: DefaultPragueBlobConfig,
 		},
 	}
 


### PR DESCRIPTION
メインネットは２週間で１時間遅れていました。
それを考慮してBlockを指定しています。