### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -724,7 +724,7 @@ func (bc *BlockChain) GetJustifiedNumber(header *types.Header) uint64 {
 	return 0
 }
 
-// getFinalizedNumber returns the highest finalized number before the specific block.
+// GetFinalizedNumber returns the highest finalized number before the specific block.
 func (bc *BlockChain) GetFinalizedNumber(header *types.Header) uint64 {
 	if p, ok := bc.engine.(consensus.PoS); ok {
 		if finalizedHeader := p.GetFinalizedHeader(bc, header); finalizedHeader != nil {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3340,7 +3340,7 @@ func preShanghaiConfig() *params.ChainConfig {
 	return &config
 }
 
-// TestEIP2718TransitionWithParliaConfig tests EIP-2718 with Parlia Config.
+// TestEIP2718TransitionWithOasysConfig tests EIP-2718 with Parlia Config.
 func TestEIP2718TransitionWithOasysConfig(t *testing.T) {
 	testEIP2718TransitionWithConfig(t, rawdb.HashScheme, preShanghaiConfig())
 	testEIP2718TransitionWithConfig(t, rawdb.PathScheme, preShanghaiConfig())

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -102,7 +102,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	return hc, nil
 }
 
-// getJustifiedNumber returns the highest justified blockNumber on the branch including and before `header`.
+// GetJustifiedNumber returns the highest justified blockNumber on the branch including and before `header`.
 func (hc *HeaderChain) GetJustifiedNumber(header *types.Header) uint64 {
 	if p, ok := hc.engine.(consensus.PoS); ok {
 		justifiedBlockNumber, _, err := p.GetJustifiedNumberAndHash(hc, []*types.Header{header})
@@ -115,7 +115,7 @@ func (hc *HeaderChain) GetJustifiedNumber(header *types.Header) uint64 {
 	return 0
 }
 
-// getFinalizedNumber returns the highest finalized number before the specific block.
+// GetFinalizedNumber returns the highest finalized number before the specific block.
 func (hc *HeaderChain) GetFinalizedNumber(header *types.Header) uint64 {
 	if p, ok := hc.engine.(consensus.PoS); ok {
 		if finalizedHeader := p.GetFinalizedHeader(hc, header); finalizedHeader != nil {


### PR DESCRIPTION
fix inconsistent function name in comment