### PR TITLE
enable fullnode by abjusting snapshot save checkpoint

### DIFF
--- a/consensus/oasys/contract.go
+++ b/consensus/oasys/contract.go
@@ -14,7 +14,6 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -236,20 +235,6 @@ func (p *nextValidators) SortByOwner() {
 	p.Stakes = sortedStakes
 	p.VoteAddresses = sortedVoteAddresses
 }
-
-// callmsg
-type callmsg struct {
-	ethereum.CallMsg
-}
-
-func (m callmsg) From() common.Address { return m.CallMsg.From }
-func (m callmsg) Nonce() uint64        { return 0 }
-func (m callmsg) CheckNonce() bool     { return false }
-func (m callmsg) To() *common.Address  { return m.CallMsg.To }
-func (m callmsg) GasPrice() *big.Int   { return m.CallMsg.GasPrice }
-func (m callmsg) Gas() uint64          { return m.CallMsg.Gas }
-func (m callmsg) Value() *big.Int      { return m.CallMsg.Value }
-func (m callmsg) Data() []byte         { return m.CallMsg.Data }
 
 func (c *Oasys) IsSystemTransaction(tx *types.Transaction, header *types.Header) (bool, error) {
 	// deploy transaction

--- a/consensus/oasys/oasys.go
+++ b/consensus/oasys/oasys.go
@@ -1448,10 +1448,10 @@ func (c *Oasys) getNextValidators(chain consensus.ChainHeaderReader, header *typ
 	if snap.Environment.IsEpoch(number) {
 		if fromHeader && c.chainConfig.IsFastFinalityEnabled(header.Number) {
 			if validators, err = getValidatorsFromHeader(header); err != nil {
-				log.Warn("failed to get validators from header", "in", "getNextValidators", "hash", header.Hash(), "number", number, "err", err)
+				err = fmt.Errorf("failed to get validators from header, blockNumber: %d, parentHash: %s, error: %v", number, header.ParentHash, err)
+				return
 			}
 		}
-		// If not fast finality or failed to get validators from header
 		if validators == nil {
 			if validators, err = getNextValidators(c.chainConfig, c.ethAPI, header.ParentHash, snap.Environment.Epoch(number), number); err != nil {
 				err = fmt.Errorf("failed to get next validators, blockNumber: %d, parentHash: %s, error: %v", number, header.ParentHash, err)
@@ -1600,7 +1600,8 @@ func (c *Oasys) environment(chain consensus.ChainHeaderReader, header *types.Hea
 	if snap.Environment.IsEpoch(number) {
 		if fromHeader && chain.Config().IsFastFinalityEnabled(header.Number) {
 			if env, err = getEnvironmentFromHeader(header); err != nil {
-				log.Warn("failed to get environment value from header", "in", "environment", "hash", header.Hash(), "number", number, "err", err)
+				err = fmt.Errorf("failed to get environment value from header, blockNumber: %d, parentHash: %s, error: %v", number, header.ParentHash, err)
+				return
 			}
 		}
 		// If not fast finality or failed to get environment from header

--- a/consensus/oasys/oasys.go
+++ b/consensus/oasys/oasys.go
@@ -436,7 +436,7 @@ func (c *Oasys) verifyCascadingFields(chain consensus.ChainHeaderReader, header 
 }
 
 // getParent returns the parent of a given block.
-func (o *Oasys) getParent(chain consensus.ChainHeaderReader, header *types.Header, parents []*types.Header) (*types.Header, error) {
+func (c *Oasys) getParent(chain consensus.ChainHeaderReader, header *types.Header, parents []*types.Header) (*types.Header, error) {
 	var parent *types.Header
 	number := header.Number.Uint64()
 	if len(parents) > 0 {
@@ -452,8 +452,8 @@ func (o *Oasys) getParent(chain consensus.ChainHeaderReader, header *types.Heade
 }
 
 // verifyVoteAttestation checks whether the vote attestation in the header is valid.
-func (o *Oasys) verifyVoteAttestation(chain consensus.ChainHeaderReader, header *types.Header, parents []*types.Header, env *params.EnvironmentValue) error {
-	attestation, err := getVoteAttestationFromHeader(header, o.chainConfig, o.config, env.IsEpoch(header.Number.Uint64()))
+func (c *Oasys) verifyVoteAttestation(chain consensus.ChainHeaderReader, header *types.Header, parents []*types.Header, env *params.EnvironmentValue) error {
+	attestation, err := getVoteAttestationFromHeader(header, c.chainConfig, c.config, env.IsEpoch(header.Number.Uint64()))
 	if err != nil {
 		return err
 	}
@@ -468,7 +468,7 @@ func (o *Oasys) verifyVoteAttestation(chain consensus.ChainHeaderReader, header 
 	}
 
 	// Get parent block
-	parent, err := o.getParent(chain, header, parents)
+	parent, err := c.getParent(chain, header, parents)
 	if err != nil {
 		return err
 	}
@@ -488,7 +488,7 @@ func (o *Oasys) verifyVoteAttestation(chain consensus.ChainHeaderReader, header 
 	if len(parents) > 0 {
 		headers = parents
 	}
-	justifiedBlockNumber, justifiedBlockHash, err := o.GetJustifiedNumberAndHash(chain, headers)
+	justifiedBlockNumber, justifiedBlockHash, err := c.GetJustifiedNumberAndHash(chain, headers)
 	if err != nil {
 		return errors.New("unexpected error when getting the highest justified number and hash")
 	}
@@ -498,11 +498,11 @@ func (o *Oasys) verifyVoteAttestation(chain consensus.ChainHeaderReader, header 
 	}
 
 	// The snapshot should be the targetNumber-1 block's snapshot.
-	snap, err := o.snapshot(chain, parent.Number.Uint64()-1, parent.ParentHash, nil)
+	snap, err := c.snapshot(chain, parent.Number.Uint64()-1, parent.ParentHash, nil)
 	if err != nil {
 		return err
 	}
-	validators, err := o.getNextValidators(chain, header, snap, true)
+	validators, err := c.getNextValidators(chain, header, snap, true)
 	if err != nil {
 		return fmt.Errorf("failed to get validators, in: verifyVoteAttestation, err: %v", err)
 	}
@@ -656,11 +656,11 @@ func getVoteAttestationFromHeader(header *types.Header, chainConfig *params.Chai
 // Decode vote atestation from the block header. It is a wrapper method that allows
 // calls from outside the consensus engine. The provided block header may depend on
 // an unknown ancestor, so it must not access the Environment or Snapshot.
-func (o *Oasys) DecodeVoteAttestation(header *types.Header) *types.VoteAttestation {
-	attestation, _ := getVoteAttestationFromHeader(header, o.chainConfig, o.config, false)
+func (c *Oasys) DecodeVoteAttestation(header *types.Header) *types.VoteAttestation {
+	attestation, _ := getVoteAttestationFromHeader(header, c.chainConfig, c.config, false)
 	if attestation == nil {
 		// Possible epoch block.
-		attestation, _ = getVoteAttestationFromHeader(header, o.chainConfig, o.config, true)
+		attestation, _ = getVoteAttestationFromHeader(header, c.chainConfig, c.config, true)
 	}
 	return attestation
 }

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1  // Major version component of the current release
 	Minor = 8  // Minor version component of the current release
-	Patch = 1  // Patch version component of the current release
+	Patch = 2  // Patch version component of the current release
 	Meta  = "" // Version metadata to append to the version string
 )


### PR DESCRIPTION
Fullnode運用でエラーになる原因は、Snapshotを保存する間隔にありました。
これを、Epochで割れる数に変更しました。

あと、HeaderにValidatorセットが入っていない古いブロックについては、BlockHeaderのValidationをスキップしています。
これにより、安定してSyncできるようになりました。
