### PR TITLE
add a flag to disable/enable tx indexer

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -99,6 +99,7 @@ var (
 		utils.SnapshotFlag,
 		utils.TxLookupLimitFlag, // deprecated
 		utils.TransactionHistoryFlag,
+		utils.DisableTxIndexerFlag,
 		utils.BlockHistoryFlag,
 		// utils.ChainHistoryFlag, // disabled in bsc
 		utils.LogHistoryFlag,


### PR DESCRIPTION
TxIndexerをDefaultでDisableにした。
[パフォーマンスが落ちるらしいから](https://github.com/bnb-chain/bsc/pull/3141)
RPCとか向けにFlagでEnableにできるようにした。
