### PR TITLE
chore: fix function comment mismatch in ckzgVerifyCellProofBatch

### DIFF
--- a/crypto/kzg4844/kzg4844_ckzg_cgo.go
+++ b/crypto/kzg4844/kzg4844_ckzg_cgo.go
@@ -150,7 +150,9 @@ func ckzgComputeCellProofs(blob *Blob) ([]Proof, error) {
 	return p, nil
 }
 
-// ckzgVerifyCellProofs verifies that the blob data corresponds to the provided commitment.
+// ckzgVerifyCellProofBatch verifies a batch of cell proofs corresponding to the blobs and commitments.
+// Expects length of blobs and commitments to be equal.
+// Expects length of cellProofs be 128 * length of blobs.
 func ckzgVerifyCellProofBatch(blobs []Blob, commitments []Commitment, cellProofs []Proof) error {
 	ckzgIniter.Do(ckzgInit)
 	var (


### PR DESCRIPTION

Fixed the comment for the `ckzgVerifyCellProofBatch` function in `kzg4844_ckzg_cgo.go` to accurately reflect its batch verification functionality and match the actual function name. 

The previous comment had naming inconsistencies and did not properly describe the function's purpose of verifying batches of cell proofs against multiple blobs and commitments.