### PR TITLE
integrate plugin build into main build flow for ABI compatibility

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -7,96 +7,101 @@ on:
 
 jobs:
   build-and-sign:
-    name: Build and sign (${{ matrix.goarch }})
+    name: Build and sign (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - goarch: amd64
+          - arch: amd64
             runner: ubuntu-latest
-          - goarch: arm64
+          - arch: arm64
             runner: ubuntu-24.04-arm
-
     permissions:
       id-token: write
       contents: read
-
     steps:
-      - name: Cleanup
-        run: |
-          echo "Before cleanup"
-          df -h
-
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo apt-get clean
-          sudo apt-get autoremove -y
-          sudo docker system prune -af
-
-          echo "After cleanup"
-          df -h
-
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y git ca-certificates
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.10"
+          go-version-file: go.mod
           cache: true
 
+      - name: Compute plugin version
+        id: plugin-version
+        run: echo "value=${GITHUB_REF_NAME#plugin-v}" >> "$GITHUB_OUTPUT"
+
       - name: Build plugin
+        uses: docker/bake-action@v6
         env:
-          GOOS: linux
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 1
-          CGO_CFLAGS: -O -D__BLST_PORTABLE__
-          CGO_CFLAGS_ALLOW: -O -D__BLST_PORTABLE__
+          GIT_COMMIT: ${{ github.sha }}
+          GIT_VERSION: ${{ github.ref_name }}
+          PLUGIN_VERSION: ${{ steps.plugin-version.outputs.value }}
+        with:
+          files: docker-bake.hcl
+          targets: plugin-binaries
+          set: |
+            *.cache-from=type=gha,scope=plugin-${{ matrix.arch }}
+            *.cache-to=type=gha,scope=plugin-${{ matrix.arch }},mode=max
+            plugin-binaries.output=type=local,dest=./binaries
+
+      - name: Rename plugin binary to match CDN naming convention
         run: |
-          out="suspicious_txfilter-linux-${{ matrix.goarch }}.so"
-          plugin_version="${GITHUB_REF_NAME#plugin-v}"
-          go build -buildmode=plugin -trimpath -v -tags urfave_cli_no_docs,ckzg,purego \
-            -ldflags "-X main.version=${plugin_version}" \
-            -o "$out" \
-            txfilter/plugindummy/main.go
+          mv binaries/suspicious_txfilter.so binaries/suspicious_txfilter_linux_${{ matrix.arch }}.so
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
-      - name: Cosign sign blob (keyless)
+      - name: Sign plugin
         run: |
-          so="suspicious_txfilter-linux-${{ matrix.goarch }}.so"
-          cosign sign-blob --yes --new-bundle-format --bundle "${so}.bundle" "$so"
+          cosign sign-blob --yes --new-bundle-format \
+            --bundle binaries/suspicious_txfilter_linux_${{ matrix.arch }}.so.bundle \
+            binaries/suspicious_txfilter_linux_${{ matrix.arch }}.so
 
-      - name: Upload artifact
+      - name: Create plugin metadata
+        run: |
+          go run txfilter/cmd/createmeta/metadata_creator.go \
+            binaries/suspicious_txfilter_linux_${{ matrix.arch }}.so.bundle \
+            - \
+            binaries/suspicious_txfilter_linux_${{ matrix.arch }}.json \
+            "${{ steps.plugin-version.outputs.value }}" \
+            "https://github.com/${{ github.repository }}/.github/workflows/release-plugin.yml@refs/tags/${{ github.ref_name }}" \
+            "https://token.actions.githubusercontent.com"
+
+      - name: Compress plugin binaries
+        run: |
+          cd binaries && zip -q - \
+            suspicious_txfilter_linux_${{ matrix.arch }}.so \
+            suspicious_txfilter_linux_${{ matrix.arch }}.so.bundle \
+            suspicious_txfilter_linux_${{ matrix.arch }}.json \
+            > ../suspicious_txfilter-${{ github.ref_name }}-linux-${{ matrix.arch }}.zip
+
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: suspicious_txfilter-linux-${{ matrix.goarch }}
-          path: |
-            suspicious_txfilter-linux-${{ matrix.goarch }}.so
-            suspicious_txfilter-linux-${{ matrix.goarch }}.so.bundle
+          name: ${{ github.ref_name }}-${{ matrix.arch }}
+          path: suspicious_txfilter-*.zip
 
   release:
-    name: Publish GitHub Release
+    name: Release
     needs: build-and-sign
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
-      - name: Download build artifacts
+      - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: suspicious_txfilter-linux-*
+          pattern: "${{ github.ref_name }}-*"
           merge-multiple: true
 
       - name: Create sha256sums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,32 +7,24 @@ on:
 
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    permissions:
+      packages: write
+      contents: read
     steps:
-      - name: Cleanup
-        run: |
-          echo "Before cleanup"
-          df -h
-
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo apt-get clean
-          sudo apt-get autoremove -y
-          sudo docker system prune -af
-
-          echo "After cleanup"
-          df -h
-
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,38 +36,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create binaries directory
-        run: mkdir ./binaries
-
-      - name: Build and Push
+      - name: Build and push geth
         uses: docker/bake-action@v6
         env:
           REGISTRY: ghcr.io
           REPOSITORY: ${{ github.repository }}
           GIT_COMMIT: ${{ github.sha }}
           GIT_VERSION: ${{ github.ref_name }}
-          IMAGE_TAGS: ${{ github.ref_name }}
+          IMAGE_TAGS: "${{ github.ref_name }}-${{ matrix.arch }}"
         with:
           files: docker-bake.hcl
+          targets: geth,binaries
           push: true
           set: |
-            *.platform=linux/amd64,linux/arm64
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-from=type=gha,scope=${{ matrix.arch }}
+            *.cache-to=type=gha,scope=${{ matrix.arch }},mode=max
             binaries.output=type=local,dest=./binaries
 
-      - name: Check version label
-        run: 'binaries/linux_amd64/geth version | grep -q "Version: $(echo ${{ github.ref_name }} | cut -c 2-10)"'
+      - name: Check geth version label
+        run: 'binaries/geth version | grep -q "Version: $(echo ${{ github.ref_name }} | cut -c 2-10)"'
 
-      - name: Compress Binaries
+      - name: Compress geth binary
         run: |
-          (cd binaries/linux_amd64 && zip -q - geth) > geth-${{ github.ref_name }}-linux-amd64.zip
-          (cd binaries/linux_arm64 && zip -q - geth) > geth-${{ github.ref_name }}-linux-arm64.zip
+          (cd binaries && zip -q - geth) > geth-${{ github.ref_name }}-linux-${{ matrix.arch }}.zip
 
       - name: Create genesis.zip
+        if: matrix.arch == 'amd64'
         run: zip -r genesis.zip genesis
 
       - name: Create setup.sh
+        if: matrix.arch == 'amd64'
         run: |
           sed -e 's#__REPOSITORY__#${{ github.repository }}#' .github/setup_template.sh | \
           sed -e 's#__RELEASE__#${{ github.ref_name }}#' > setup.sh
@@ -83,22 +73,46 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}-${{ matrix.arch }}
           path: |
             geth-*.zip
             genesis.zip
             setup.sh
 
+  docker-manifest:
+    name: Docker manifest
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-amd64 \
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-arm64
+
   release:
     name: Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Download Artifact
+      - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.ref_name }}
           path: artifacts
+          pattern: "${{ github.ref_name }}-*"
+          merge-multiple: true
 
       - name: Create sha256sums.txt
         run: (cd artifacts && sha256sum *) > sha256sums.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.24.10-bookworm as builder
+FROM golang:1.24.10-bookworm as base
 
 # Support setting various labels on the final image
 ARG COMMIT=""
@@ -18,17 +18,31 @@ ADD . /go-ethereum
 # For blst
 ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
 ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
-RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
-# Binary extraction stage
+FROM base as geth-builder
+# NOTE: -static is removed because Go's plugin.Open() uses dlopen() internally,
+# which does not work in statically-linked binaries. The final image uses
+# distroless/base-debian12 (glibc included), so dynamic linking works fine.
+# RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
+RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
+
+FROM base as plugin-builder
+ARG PLUGIN_VERSION=""
+RUN cd /go-ethereum && go run build/ci.go plugin \
+    ${PLUGIN_VERSION:+-version "$PLUGIN_VERSION"}
+
+# Binary extraction stages
 FROM scratch as binaries
-COPY --from=builder /go-ethereum/build/bin/geth /geth
+COPY --from=geth-builder /go-ethereum/build/bin/geth /geth
+
+FROM scratch as plugin-binaries
+COPY --from=plugin-builder /go-ethereum/build/bin/suspicious_txfilter.so /suspicious_txfilter.so
 
 # Final stage
 FROM gcr.io/distroless/base-debian12
-COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/geth
-COPY --from=builder /etc/ssl /etc/ssl
-COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=geth-builder /go-ethereum/build/bin/geth /usr/local/bin/geth
+COPY --from=geth-builder /etc/ssl /etc/ssl
+COPY --from=geth-builder /usr/share/ca-certificates /usr/share/ca-certificates
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]

--- a/Makefile
+++ b/Makefile
@@ -16,28 +16,32 @@ geth:
 	$(GORUN) build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
-	# @$(MAKE) plugin
 
 #? plugin: Build the suspicious txfilter plugin.
-# The plugin must be built with the exact same Go version, build tags, and go.mod as the test binary.
+# Uses build/ci.go to share toolchain setup and build tags with the main binary.
 plugin:
 	@echo "Building suspicious txfilter plugin..."
-	@go build -buildmode=plugin -trimpath -tags urfave_cli_no_docs,ckzg,purego -o ./build/bin/suspicious_txfilter.so txfilter/plugindummy/main.go
+	@$(GORUN) build/ci.go plugin
 	@echo "Plugin built successfully."
 
 #? plugin-test: Build / sign / create metadata for the suspicious txfilter plugin for testing.
+#?              Usage: make plugin-test [BLOCKED=true]
+BLOCKED ?= false
+PLUGIN_TEST_DIR = ./txfilter/testdata
+PLUGIN_TEST_SO = $(PLUGIN_TEST_DIR)/suspicious_txfilter.so
+PLUGIN_TEST_BUNDLE = $(PLUGIN_TEST_SO).bundle
+PLUGIN_TEST_JSON = $(PLUGIN_TEST_DIR)/suspicious_txfilter.json
 plugin-test:
-	@echo "Building suspicious txfilter plugin for testing..."
-	@go build -buildmode=plugin -ldflags "-X main.version=1.0.0 -X main.blockedByPlugin=false" -o ./txfilter/testdata/suspicious_txfilter-v1.so ./txfilter/plugindummy/main.go
-	@go build -buildmode=plugin -ldflags "-X main.version=2.0.0 -X main.blockedByPlugin=true" -o ./txfilter/testdata/suspicious_txfilter-v2.so ./txfilter/plugindummy/main.go
-	@echo "Plugin for testing built successfully."
-	@echo "Sign the plugin...(the key password is empty)"
-	@cosign sign-blob --key ./txfilter/testdata/cosign-test.key --bundle ./txfilter/testdata/suspicious_txfilter-v1.so.bundle ./txfilter/testdata/suspicious_txfilter-v1.so
-	@cosign sign-blob --key ./txfilter/testdata/cosign-test.key --bundle ./txfilter/testdata/suspicious_txfilter-v2.so.bundle ./txfilter/testdata/suspicious_txfilter-v2.so
+	@echo "Building suspicious txfilter plugin (blocked=$(BLOCKED))..."
+	@$(GORUN) build/ci.go plugin -version 1.0.0 $(if $(filter true,$(BLOCKED)),-blocked) -o $(PLUGIN_TEST_SO)
+	@echo "Plugin built successfully."
+
+	@echo "Signing plugin...(the key password is empty)"
+	@COSIGN_PASSWORD="" cosign sign-blob --yes --new-bundle-format --tlog-upload=false --key $(PLUGIN_TEST_DIR)/cosign-test.key --bundle $(PLUGIN_TEST_BUNDLE) $(PLUGIN_TEST_SO)
 	@echo "Plugin signed successfully."
-	@echo "Create plugin metadata..."
-	@go run txfilter/cmd/createmeta/metadata_creator.go ./txfilter/testdata/suspicious_txfilter-v1.so.bundle ./txfilter/testdata/cosign-test.pub ./txfilter/testdata/suspicious_txfilter-v1.json 1.0.0
-	@go run txfilter/cmd/createmeta/metadata_creator.go ./txfilter/testdata/suspicious_txfilter-v2.so.bundle ./txfilter/testdata/cosign-test.pub ./txfilter/testdata/suspicious_txfilter-v2.json 2.0.0
+
+	@echo "Creating plugin metadata..."
+	@go run txfilter/cmd/createmeta/metadata_creator.go $(PLUGIN_TEST_BUNDLE) $(PLUGIN_TEST_DIR)/cosign-test.pub $(PLUGIN_TEST_JSON) 1.0.0
 	@echo "Plugin metadata created successfully."
 
 #? faucet: Build faucet

--- a/build/ci.go
+++ b/build/ci.go
@@ -28,8 +28,9 @@ Available commands are:
 	check_generate -- verifies that 'go generate' and 'go mod tidy' do not produce changes
 	check_baddeps  -- verifies that certain dependencies are avoided
 
-	install    [ -arch architecture ] [ -cc compiler ] [ packages... ] -- builds packages and executables
-	test       [ -coverage ] [ packages... ]                           -- runs the tests
+	install    [ -arch architecture ] [ -cc compiler ] [ packages... ]                        -- builds packages and executables
+	plugin     [ -arch architecture ] [ -cc compiler ] [ -o output ] [ -version ver ] [ -blocked ] -- builds the suspicious txfilter plugin
+	test       [ -coverage ] [ packages... ]                                                 -- runs the tests
 
 	archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -signify key-envvar ] [ -upload dest ] -- archives build artifacts
 	importkeys                                                                                  -- imports signing keys from env
@@ -43,7 +44,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
@@ -156,6 +159,8 @@ func main() {
 	switch os.Args[1] {
 	case "install":
 		doInstall(os.Args[2:])
+	case "plugin":
+		doPlugin(os.Args[2:])
 	case "test":
 		doTest(os.Args[2:])
 	case "lint":
@@ -192,24 +197,15 @@ func doInstall(cmdline []string) {
 		output     = flag.String("o", "", "Output directory for build artifacts")
 	)
 	flag.CommandLine.Parse(cmdline)
-	env := build.Env()
 
-	// Configure the toolchain.
-	tc := build.GoToolchain{GOARCH: *arch, CC: *cc}
-	if *dlgo {
-		csdb := download.MustLoadChecksums("build/checksums.txt")
-		tc.Root = build.DownloadGo(csdb)
-	}
-	// Disable CLI markdown doc generation in release builds.
-	buildTags := []string{"urfave_cli_no_docs"}
+	env, tc, buildTags := buildEnvAndToolchain(*dlgo, *arch, *cc)
 
-	// Enable linking the CKZG library since we can make it work with additional flags.
-	if env.UbuntuVersion != "trusty" {
-		buildTags = append(buildTags, "ckzg")
-	}
+	// Compute ABI fingerprint and embed in main binary for plugin compatibility check.
+	fingerprint := computePluginBuildFingerprint(tc, buildTags)
 
 	// Configure the build.
-	gobuild := tc.Go("build", buildFlags(env, *staticlink, buildTags)...)
+	gobuild := tc.Go("build", buildFlags(env, *staticlink, buildTags,
+		"-X", "github.com/ethereum/go-ethereum/core.pluginBuildFingerprint="+fingerprint)...)
 
 	// We use -trimpath to avoid leaking local paths into the built executables.
 	gobuild.Args = append(gobuild.Args, "-trimpath")
@@ -237,8 +233,54 @@ func doInstall(cmdline []string) {
 	}
 }
 
+func doPlugin(cmdline []string) {
+	var (
+		dlgo    = flag.Bool("dlgo", false, "Download Go and build with it")
+		arch    = flag.String("arch", "", "Architecture to cross build for")
+		cc      = flag.String("cc", "", "C compiler to cross build with")
+		output  = flag.String("o", "", "Output path for plugin binary")
+		pver    = flag.String("version", "", "Plugin version to embed")
+		blocked = flag.Bool("blocked", false, "Set blockedByPlugin=true (for testing)")
+	)
+	flag.CommandLine.Parse(cmdline)
+
+	// Same toolchain setup and base tags as doInstall.
+	_, tc, buildTags := buildEnvAndToolchain(*dlgo, *arch, *cc)
+
+	// Compute build fingerprint (same base tags as doInstall).
+	fingerprint := computePluginBuildFingerprint(tc, buildTags)
+
+	// Build ldflags.
+	var ld []string
+	ld = append(ld, "-X", "main.BuildFingerprint="+fingerprint)
+	if *pver != "" {
+		ld = append(ld, "-X", "main.version="+*pver)
+	}
+	if *blocked {
+		ld = append(ld, "-X", "main.blockedByPlugin=true")
+	}
+
+	var flags []string
+	flags = append(flags, "-ldflags", strings.Join(ld, " "))
+	flags = append(flags, "-tags", strings.Join(buildTags, ","))
+
+	gobuild := tc.Go("build", flags...)
+	gobuild.Args = append(gobuild.Args, "-buildmode=plugin", "-trimpath", "-v")
+
+	outputPath := executablePath("suspicious_txfilter.so")
+	if *output != "" {
+		outputPath = *output
+	}
+	gobuild.Args = append(gobuild.Args, "-o", outputPath)
+	gobuild.Args = append(gobuild.Args, "txfilter/plugindummy/main.go")
+
+	fmt.Println("Building suspicious txfilter plugin...")
+	build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: gobuild.Args, Env: gobuild.Env})
+}
+
 // buildFlags returns the go tool flags for building.
-func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (flags []string) {
+// extraLDFlags are appended to the linker flags (e.g., "-X", "pkg.var=value" pairs).
+func buildFlags(env build.Environment, staticLinking bool, buildTags []string, extraLDFlags ...string) (flags []string) {
 	var ld []string
 	// See https://github.com/golang/go/issues/33772#issuecomment-528176001
 	// We need to set --buildid to the linker here, and also pass --build-id to the
@@ -269,6 +311,7 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		}
 		ld = append(ld, "-extldflags", "'"+strings.Join(extld, " ")+"'")
 	}
+	ld = append(ld, extraLDFlags...)
 	if len(ld) > 0 {
 		flags = append(flags, "-ldflags", strings.Join(ld, " "))
 	}
@@ -1185,4 +1228,74 @@ func doPurge(cmdline []string) {
 func doSanityCheck() {
 	csdb := download.MustLoadChecksums("build/checksums.txt")
 	csdb.DownloadAndVerifyAll()
+}
+
+// buildEnvAndToolchain returns the shared build environment, toolchain, and
+// base build tags. Both doInstall and doPlugin use this to ensure identical
+// configuration.
+func buildEnvAndToolchain(dlgo bool, arch, cc string) (build.Environment, build.GoToolchain, []string) {
+	env := build.Env()
+
+	tc := build.GoToolchain{GOARCH: arch, CC: cc}
+	if dlgo {
+		csdb := download.MustLoadChecksums("build/checksums.txt")
+		tc.Root = build.DownloadGo(csdb)
+	}
+
+	// Base build tags — shared between main binary and plugin.
+	// Disable CLI markdown doc generation in release builds.
+	buildTags := []string{"urfave_cli_no_docs"}
+	// Enable linking the CKZG library since we can make it work with additional flags.
+	if env.UbuntuVersion != "trusty" {
+		buildTags = append(buildTags, "ckzg")
+	}
+
+	return env, tc, buildTags
+}
+
+// computePluginBuildFingerprint computes a fingerprint from go.mod, go.sum,
+// Go toolchain version, base build tags, and target OS/ARCH. This is embedded
+// in both the main binary and the plugin to verify build compatibility at
+// plugin load time. Both doInstall and doPlugin must pass the same baseBuildTags
+// (the shared tags from buildEnvAndToolchain, before adding target-specific
+// tags like "purego" or "osusergo").
+func computePluginBuildFingerprint(tc build.GoToolchain, baseBuildTags []string) string {
+	h := sha256.New()
+
+	// go.mod (contains go directive and toolchain directive that affect build behavior)
+	goModData, err := os.ReadFile("go.mod")
+	if err != nil {
+		log.Fatal("failed to read go.mod for ABI fingerprint: ", err)
+	}
+	h.Write(goModData)
+
+	// go.sum (dependency content hashes)
+	goSumData, err := os.ReadFile("go.sum")
+	if err != nil {
+		log.Fatal("failed to read go.sum for ABI fingerprint: ", err)
+	}
+	h.Write(goSumData)
+
+	// Go toolchain version (from the actual toolchain, not the build script's runtime)
+	goVersionCmd := tc.Go("version")
+	goVersionOut, err := goVersionCmd.Output()
+	if err != nil {
+		log.Fatal("failed to get Go version for ABI fingerprint: ", err)
+	}
+	h.Write(bytes.TrimSpace(goVersionOut))
+
+	// Base build tags (shared between main binary and plugin)
+	h.Write([]byte(strings.Join(baseBuildTags, ",")))
+
+	// Target OS/ARCH
+	targetOS, targetArch := runtime.GOOS, runtime.GOARCH
+	if tc.GOOS != "" {
+		targetOS = tc.GOOS
+	}
+	if tc.GOARCH != "" {
+		targetArch = tc.GOARCH
+	}
+	h.Write([]byte(targetOS + "/" + targetArch))
+
+	return hex.EncodeToString(h.Sum(nil))[:16]
 }

--- a/core/suspicious_txfilter.go
+++ b/core/suspicious_txfilter.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -42,8 +43,9 @@ const (
 	// The suspicious txfilter plugin metadata file name
 	PluginMetadataFileName = "suspicious_txfilter.json"
 
-	// Exported symbol name in the plugin .so.
-	pluginSymbolName = "Plugin"
+	// Exported symbol names in the plugin .so.
+	pluginSymbolName           = "Plugin"
+	pluginBuildFingerprintName = "BuildFingerprint"
 )
 
 var (
@@ -54,6 +56,10 @@ var (
 	// multiple layers and changing many interfaces. Modifying those interfaces
 	// would significantly increase the merge conflict effort.
 	SuspiciousTxfilterGlobal *SuspiciousTxfilter
+
+	// pluginBuildFingerprint is set by -ldflags in build/ci.go doInstall().
+	// It is compared against the plugin's BuildFingerprint to verify build compatibility.
+	pluginBuildFingerprint string
 )
 
 // SuspiciousTxfilterPlugin is the interface that a loaded plugin must implement.
@@ -100,9 +106,12 @@ func NewSuspiciousTxfilter(config *params.ChainConfig, datadir string, exitCh ch
 		client:  &http.Client{Timeout: 30 * time.Second},
 	}
 
+	log.Info("Fetching suspicious txfilter plugin metadata", "url", s.pluginMetadataDownloadURL())
 	if _, err := s.fetchPluginMetadata(); err != nil {
 		return nil, fmt.Errorf("failed to download plugin metadata: %w", err)
 	}
+	log.Info("Suspicious txfilter plugin metadata loaded",
+		"version", s.metadata.Load().Version, "disable", s.metadata.Load().Disable)
 
 	// Do background loading of the plugin
 	go func() {
@@ -111,15 +120,17 @@ func NewSuspiciousTxfilter(config *params.ChainConfig, datadir string, exitCh ch
 
 		// Try to load existing plugin, fetch if missing or invalid
 		pluginPath := s.pluginPath()
-		if _, err := os.Stat(pluginPath); os.IsNotExist(err) || s.loadPlugin() != nil {
-			if err := s.fetchPlugin(); err != nil {
-				log.Error("Failed to download suspicious txfilter plugin", "err", err)
-				return
-			}
-			if err := s.loadPlugin(); err != nil {
-				log.Error("Failed to load suspicious txfilter plugin", "err", err)
-				return
-			}
+		if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+			log.Info("Plugin not found locally", "path", pluginPath)
+		} else if err := s.loadPlugin(); err != nil {
+			log.Warn("Failed to load existing plugin, re-downloading", "path", pluginPath, "err", err)
+		} else {
+			return // loaded successfully
+		}
+		if err := s.fetchPlugin(); err != nil {
+			log.Error("Failed to download suspicious txfilter plugin", "err", err)
+		} else if err := s.loadPlugin(); err != nil {
+			log.Error("Failed to load suspicious txfilter plugin", "err", err)
 		}
 	}()
 
@@ -133,7 +144,72 @@ func (s *SuspiciousTxfilter) IsReady() bool {
 	return true
 }
 
-func (s *SuspiciousTxfilter) VerifyPluginVersion(p *plugin.Plugin) error {
+// verifyPluginIntegrity verifies that the plugin .so file has not been tampered
+// with by checking its Cosign signature bundle against the expected identity.
+func (s *SuspiciousTxfilter) verifyPluginIntegrity(bundle bundle.Bundle, metadata *SuspiciousTxfilterPluginMetadata) error {
+	if s.verifier == nil {
+		return fmt.Errorf("verifier not initialized")
+	}
+
+	pluginPath := s.pluginPath()
+	file, err := os.Open(pluginPath)
+	if err != nil {
+		return fmt.Errorf("failed to open plugin file: %w", err)
+	}
+	defer file.Close()
+
+	artifactPolicy := sigverify.WithArtifact(file)
+
+	if metadata.IsKeyless {
+		// Execute the verification
+		// - WithArtifact: The artifact to verify
+		// - WithCertificateIdentity: The identity of the certificate that signed the artifact
+		if _, err := s.verifier.Verify(&bundle, sigverify.NewPolicy(
+			artifactPolicy,
+			sigverify.WithCertificateIdentity(sigverify.CertificateIdentity{
+				SubjectAlternativeName: sigverify.SubjectAlternativeNameMatcher{
+					SubjectAlternativeName: *metadata.CertificateIdentity,
+				},
+				Issuer: sigverify.IssuerMatcher{
+					Issuer: *metadata.CertificateIssuer,
+				},
+			}),
+		)); err != nil {
+			return fmt.Errorf("failed to verify bundle: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := s.verifier.Verify(&bundle, sigverify.NewPolicy(artifactPolicy, sigverify.WithKey())); err != nil {
+		return fmt.Errorf("failed to verify bundle: %w", err)
+	}
+	return nil
+}
+
+// verifyPluginBuild checks that the plugin was built with the same go.mod,
+// go.sum, Go version, and target OS/ARCH as the main binary.
+func verifyPluginBuild(p *plugin.Plugin) error {
+	if pluginBuildFingerprint == "" {
+		return nil // development build without fingerprint
+	}
+	sym, err := p.Lookup(pluginBuildFingerprintName)
+	if err != nil {
+		log.Warn("Plugin does not export BuildFingerprint, skipping build compatibility check")
+		return nil
+	}
+	pluginFP, ok := sym.(*string)
+	if !ok {
+		return fmt.Errorf("plugin BuildFingerprint has unexpected type: %T", sym)
+	}
+	if *pluginFP != pluginBuildFingerprint {
+		return fmt.Errorf("build fingerprint mismatch: host=%s plugin=%s (rebuild plugin with the same go.sum and Go version)", pluginBuildFingerprint, *pluginFP)
+	}
+	return nil
+}
+
+// verifyPluginVersion checks that the loaded plugin's version matches
+// the version declared in the metadata downloaded from the CDN.
+func (s *SuspiciousTxfilter) verifyPluginVersion(p *plugin.Plugin) error {
 	metadata := s.metadata.Load()
 	if metadata == nil || metadata.Version == "" {
 		return fmt.Errorf("plugin metadata not found")
@@ -191,6 +267,7 @@ func (s *SuspiciousTxfilter) FilterTransaction(txhash common.Hash, msg *Message,
 
 func (s *SuspiciousTxfilter) fetchPlugin() error {
 	url := s.pluginDownloadURL()
+	log.Info("Downloading suspicious txfilter plugin", "url", url)
 	body, err := s.fetch(url)
 	if err != nil {
 		return fmt.Errorf("failed to download plugin: %w", err)
@@ -280,7 +357,10 @@ func (s *SuspiciousTxfilter) startReloadLoop(reloadInterval time.Duration) {
 }
 
 func (s *SuspiciousTxfilter) loadPlugin() error {
-	bundleData, err := hex.DecodeString(s.metadata.Load().BundleHex)
+	pluginPath := s.pluginPath()
+	metadata := s.metadata.Load()
+
+	bundleData, err := hex.DecodeString(metadata.BundleHex)
 	if err != nil {
 		return fmt.Errorf("failed to decode bundle hex: %w", err)
 	}
@@ -290,25 +370,33 @@ func (s *SuspiciousTxfilter) loadPlugin() error {
 		return fmt.Errorf("failed to unmarshal bundle: %w", err)
 	}
 
-	metadata := s.metadata.Load()
-
 	// It's ok to update the verifier every time, as loading new plugin is not frequent.
 	if err = s.updateVerifier(metadata); err != nil {
 		return err
 	}
 
-	if err = s.verifyPlugin(bundle, metadata); err != nil {
+	log.Info("Verifying plugin integrity", "path", pluginPath)
+	if err = s.verifyPluginIntegrity(bundle, metadata); err != nil {
 		return err
 	}
 
-	newPlugin, err := plugin.Open(s.pluginPath())
+	log.Info("Opening plugin", "path", pluginPath)
+	newPlugin, err := plugin.Open(pluginPath)
 	if err != nil {
 		return fmt.Errorf("failed to open plugin: %w", err)
 	}
 
-	if err = s.VerifyPluginVersion(newPlugin); err != nil {
+	log.Info("Verifying plugin build compatibility")
+	if err = verifyPluginBuild(newPlugin); err != nil {
+		return fmt.Errorf("failed to verify plugin build compatibility: %w", err)
+	}
+
+	log.Info("Verifying plugin version", "expected", metadata.Version)
+	if err = s.verifyPluginVersion(newPlugin); err != nil {
 		return fmt.Errorf("failed to verify plugin version: %w", err)
 	}
+
+	log.Info("Plugin loaded successfully", "version", metadata.Version)
 
 	oldPlugin := s.plugin.Load()
 
@@ -368,46 +456,6 @@ func (s *SuspiciousTxfilter) updateVerifier(metadata *SuspiciousTxfilterPluginMe
 	return nil
 }
 
-func (s *SuspiciousTxfilter) verifyPlugin(bundle bundle.Bundle, metadata *SuspiciousTxfilterPluginMetadata) error {
-	if s.verifier == nil {
-		return fmt.Errorf("verifier not initialized")
-	}
-
-	pluginPath := s.pluginPath()
-	file, err := os.Open(pluginPath)
-	if err != nil {
-		return fmt.Errorf("failed to open plugin file: %w", err)
-	}
-	defer file.Close()
-
-	artifactPolicy := sigverify.WithArtifact(file)
-
-	if metadata.IsKeyless {
-		// Execute the verification
-		// - WithArtifact: The artifact to verify
-		// - WithCertificateIdentity: The identity of the certificate that signed the artifact
-		if _, err := s.verifier.Verify(&bundle, sigverify.NewPolicy(
-			artifactPolicy,
-			sigverify.WithCertificateIdentity(sigverify.CertificateIdentity{
-				SubjectAlternativeName: sigverify.SubjectAlternativeNameMatcher{
-					SubjectAlternativeName: *metadata.CertificateIdentity,
-				},
-				Issuer: sigverify.IssuerMatcher{
-					Issuer: *metadata.CertificateIssuer,
-				},
-			}),
-		)); err != nil {
-			return fmt.Errorf("failed to verify bundle: %w", err)
-		}
-		return nil
-	}
-
-	if _, err := s.verifier.Verify(&bundle, sigverify.NewPolicy(artifactPolicy, sigverify.WithKey())); err != nil {
-		return fmt.Errorf("failed to verify bundle: %w", err)
-	}
-	return nil
-}
-
 func (s *SuspiciousTxfilter) reloadPlugin() (reloaded bool, err error) {
 	// Download the plugin metadata
 	metadataVersion, err := s.fetchPluginMetadata()
@@ -449,7 +497,7 @@ func (s *SuspiciousTxfilter) buildPluginURL(filename string) string {
 		if s.config.ChainID.Cmp(params.OasysTestnetChainConfig.ChainID) == 0 {
 			network = "testnet"
 		}
-		return fmt.Sprintf("https://cdn.%s.oasys.games/suspicious_txfilter/%s_%s_%s%s", network, fileName, osName, osArch, fileExt)
+		return fmt.Sprintf("https://cdn.%s.oasys.games/suspicious_txfilter/%s/%s_%s_%s%s", network, version.WithMeta, fileName, osName, osArch, fileExt)
 	}
 
 	// For testing

--- a/core/suspicious_txfilter_test.go
+++ b/core/suspicious_txfilter_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/internal/version"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -401,7 +402,7 @@ func TestSuspiciousTxfilter_buildPluginURL(t *testing.T) {
 		},
 	}
 	url := filter.buildPluginURL(PluginFileName)
-	expectedURL := fmt.Sprintf("https://cdn.mainnet.oasys.games/suspicious_txfilter/suspicious_txfilter_%s_%s.so", runtime.GOOS, runtime.GOARCH)
+	expectedURL := fmt.Sprintf("https://cdn.mainnet.oasys.games/suspicious_txfilter/%s/suspicious_txfilter_%s_%s.so", version.WithMeta, runtime.GOOS, runtime.GOARCH)
 	if url != expectedURL {
 		t.Errorf("Expected URL: %s, got: %s", expectedURL, url)
 	}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,6 +16,12 @@ variable "GIT_VERSION" {
   default = "v0.0.0"
 }
 
+// Plugin version without tag prefix (e.g. "1.8.4" or "1.0.0").
+// Set by the workflow after stripping "v" or "plugin-v" prefix.
+variable "PLUGIN_VERSION" {
+  default = "1.0.0"
+}
+
 variable "IMAGE_TAGS" {
   default = "${GIT_COMMIT}" // split by ","
 }
@@ -38,6 +44,7 @@ target "geth" {
   args = {
     COMMIT = "${GIT_COMMIT}"
     VERSION = "${GIT_VERSION}"
+    PLUGIN_VERSION = "${PLUGIN_VERSION}"
   }
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}:${tag}"]
@@ -48,7 +55,21 @@ target "binaries" {
   target = "binaries"
   context = "."
   args = {
+    COMMIT = "${GIT_COMMIT}"
     VERSION = "${GIT_VERSION}"
+    PLUGIN_VERSION = "${PLUGIN_VERSION}"
+  }
+  platforms = split(",", PLATFORMS)
+}
+
+target "plugin-binaries" {
+  dockerfile = "Dockerfile"
+  target = "plugin-binaries"
+  context = "."
+  args = {
+    COMMIT = "${GIT_COMMIT}"
+    VERSION = "${GIT_VERSION}"
+    PLUGIN_VERSION = "${PLUGIN_VERSION}"
   }
   platforms = split(",", PLATFORMS)
 }

--- a/txfilter/plugindummy/main.go
+++ b/txfilter/plugindummy/main.go
@@ -17,6 +17,9 @@ var version = "1.0.0"
 // blockedByPlugin can be set at build time using -ldflags "-X main.blockedByPlugin=true"
 var blockedByPlugin = "false"
 
+// BuildFingerprint is the build environment fingerprint. Set by -ldflags.
+var BuildFingerprint string
+
 type LogEntry struct {
 	Address string   `json:"address"`
 	Topics  []string `json:"topics"`


### PR DESCRIPTION
Build system (build/ci.go):
- Extract buildEnvAndToolchain() to share toolchain setup and base build tags between geth and plugin builds
- Add doPlugin() command (go run build/ci.go plugin) using the same Go toolchain and base build tags as doInstall()
- Add -blocked flag for testing (sets blockedByPlugin=true)
- Add build fingerprint (SHA256 of go.mod + go.sum + Go toolchain version + build tags + GOOS/GOARCH) embedded in both binaries via ldflags, verified at plugin load time to catch build mismatches
- Update buildFlags() to accept optional extra ldflags

Plugin loading (core/suspicious_txfilter.go):
- Add verifyPluginBuild() to check build fingerprint on plugin load
- Include geth version in plugin download URL path
- Rename verifyPlugin -> verifyPluginIntegrity for clarity
- Unexport VerifyPluginVersion (only used internally)
- Reorder verify methods to match call order in loadPlugin()
- Add logging throughout plugin load workflow

Dockerfile & CI:
- Split builder into base/geth-builder/plugin-builder stages for independent builds via BuildKit
- Remove -static from geth build (plugin.Open uses dlopen which requires dynamic linking)
- Use native ARM runners instead of QEMU for release builds
- Separate release.yml (v* geth only) and release-plugin.yml (plugin-v* plugin only) with independent versioning
- Add cosign signing and metadata JSON generation for plugin