### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/accounts/keystore/watch.go
+++ b/accounts/keystore/watch.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build (darwin && !ios && cgo) || freebsd || (linux && !arm64) || netbsd || solaris
-// +build darwin,!ios,cgo freebsd linux,!arm64 netbsd solaris
 
 package keystore
 

--- a/accounts/keystore/watch_fallback.go
+++ b/accounts/keystore/watch_fallback.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build (darwin && !cgo) || ios || (linux && arm64) || windows || (!darwin && !freebsd && !linux && !netbsd && !solaris)
-// +build darwin,!cgo ios linux,arm64 windows !darwin,!freebsd,!linux,!netbsd,!solaris
 
 // This is the fallback implementation of directory watching.
 // It is used on unsupported platforms.

--- a/common/fdlimit/fdlimit_bsd.go
+++ b/common/fdlimit/fdlimit_bsd.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build freebsd || dragonfly
-// +build freebsd dragonfly
 
 package fdlimit
 

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build linux || netbsd || openbsd || solaris
-// +build linux netbsd openbsd solaris
 
 package fdlimit
 

--- a/core/mkalloc.go
+++ b/core/mkalloc.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build none
-// +build none
 
 /*
 The mkalloc tool creates the genesis allocation constants in genesis_alloc.go

--- a/crypto/blake2b/blake2bAVX2_amd64.go
+++ b/crypto/blake2b/blake2bAVX2_amd64.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.7 && amd64 && !gccgo && !appengine
-// +build go1.7,amd64,!gccgo,!appengine
 
 package blake2b
 

--- a/crypto/blake2b/blake2b_amd64.go
+++ b/crypto/blake2b/blake2b_amd64.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.7 && amd64 && !gccgo && !appengine
-// +build !go1.7,amd64,!gccgo,!appengine
 
 package blake2b
 

--- a/crypto/blake2b/blake2b_f_fuzz_test.go
+++ b/crypto/blake2b/blake2b_f_fuzz_test.go
@@ -1,6 +1,5 @@
 // Only enable fuzzer on platforms with AVX enabled
 //go:build go1.7 && amd64 && !gccgo && !appengine
-// +build go1.7,amd64,!gccgo,!appengine
 
 package blake2b
 

--- a/crypto/blake2b/blake2b_ref.go
+++ b/crypto/blake2b/blake2b_ref.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !amd64 || appengine || gccgo
-// +build !amd64 appengine gccgo
 
 package blake2b
 

--- a/crypto/blake2b/register.go
+++ b/crypto/blake2b/register.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.9
-// +build go1.9
 
 package blake2b
 

--- a/crypto/bn256/bn256_fast.go
+++ b/crypto/bn256/bn256_fast.go
@@ -3,7 +3,6 @@
 // in the LICENSE file.
 
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 // Package bn256 implements the Optimal Ate pairing over a 256-bit Barreto-Naehrig curve.
 package bn256

--- a/crypto/bn256/bn256_slow.go
+++ b/crypto/bn256/bn256_slow.go
@@ -3,7 +3,6 @@
 // in the LICENSE file.
 
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 // Package bn256 implements the Optimal Ate pairing over a 256-bit Barreto-Naehrig curve.
 package bn256

--- a/crypto/bn256/cloudflare/gfp_decl.go
+++ b/crypto/bn256/cloudflare/gfp_decl.go
@@ -1,5 +1,4 @@
 //go:build (amd64 && !generic) || (arm64 && !generic)
-// +build amd64,!generic arm64,!generic
 
 package bn256
 

--- a/crypto/bn256/cloudflare/gfp_generic.go
+++ b/crypto/bn256/cloudflare/gfp_generic.go
@@ -1,5 +1,4 @@
 //go:build (!amd64 && !arm64) || generic
-// +build !amd64,!arm64 generic
 
 package bn256
 

--- a/crypto/secp256k1/dummy.go
+++ b/crypto/secp256k1/dummy.go
@@ -1,5 +1,4 @@
 //go:build dummy
-// +build dummy
 
 // This file is part of a workaround for `go mod vendor` which won't vendor
 // C files if there's no Go file in the same directory.

--- a/crypto/secp256k1/scalar_mult_nocgo.go
+++ b/crypto/secp256k1/scalar_mult_nocgo.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build gofuzz || !cgo
-// +build gofuzz !cgo
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !gofuzz && cgo
-// +build !gofuzz,cgo
 
 package secp256k1
 

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !nacl && !js && !wasip1 && cgo && !gofuzz && !tinygo
-// +build !nacl,!js,!wasip1,cgo,!gofuzz,!tinygo
 
 package crypto
 

--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build nacl || js || wasip1 || !cgo || gofuzz || tinygo
-// +build nacl js wasip1 !cgo gofuzz tinygo
 
 package crypto
 

--- a/crypto/signify/signify_fuzz.go
+++ b/crypto/signify/signify_fuzz.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build gofuzz
-// +build gofuzz
 
 package signify
 

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !js && !wasip1
-// +build !js,!wasip1
 
 // Package leveldb implements the key-value database layer based on LevelDB.
 package leveldb

--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build ios || js || wasip1 || tinygo
-// +build ios js wasip1 tinygo
 
 package metrics
 

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !ios && !js && !wasip1 && !tinygo
-// +build !ios,!js,!wasip1,!tinygo
 
 package metrics
 

--- a/metrics/cputime_nop.go
+++ b/metrics/cputime_nop.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build windows || js
-// +build windows js
 
 package metrics
 

--- a/metrics/cputime_unix.go
+++ b/metrics/cputime_unix.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !windows && !js && !wasip1
-// +build !windows,!js,!wasip1
 
 package metrics
 

--- a/metrics/disk_nop.go
+++ b/metrics/disk_nop.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !linux
-// +build !linux
 
 package metrics
 

--- a/metrics/syslog.go
+++ b/metrics/syslog.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package metrics
 

--- a/p2p/netutil/toobig_notwindows.go
+++ b/p2p/netutil/toobig_notwindows.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !windows
-// +build !windows
 
 package netutil
 

--- a/p2p/netutil/toobig_windows.go
+++ b/p2p/netutil/toobig_windows.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build windows
-// +build windows
 
 package netutil
 

--- a/rlp/safe.go
+++ b/rlp/safe.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build nacl || js || !cgo
-// +build nacl js !cgo
 
 package rlp
 

--- a/rlp/unsafe.go
+++ b/rlp/unsafe.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build !nacl && !js && cgo
-// +build !nacl,!js,cgo
 
 package rlp
 

--- a/rpc/ipc_js.go
+++ b/rpc/ipc_js.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build js
-// +build js
 
 package rpc
 

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
 
 package rpc
 

--- a/rpc/ipc_wasip1.go
+++ b/rpc/ipc_wasip1.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build wasip1
-// +build wasip1
 
 package rpc
 

--- a/rpc/ipc_windows.go
+++ b/rpc/ipc_windows.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build windows
-// +build windows
 
 package rpc
 

--- a/tests/fuzzers/bls12381/bls12381_fuzz.go
+++ b/tests/fuzzers/bls12381/bls12381_fuzz.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build cgo
-// +build cgo
 
 package bls
 

--- a/tests/fuzzers/bls12381/bls12381_test.go
+++ b/tests/fuzzers/bls12381/bls12381_test.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build cgo
-// +build cgo
 
 package bls
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild
